### PR TITLE
[Fix] corrections ormconfig.json entities CarsRepository.ts in create()

### DIFF
--- a/ormconfig.json
+++ b/ormconfig.json
@@ -6,7 +6,7 @@
   "password": "ignite",
   "database": "rentx",
   "migrations": ["./src/shared/infra/typeorm/migrations/*.ts"],
-  "entities": ["./src/modules/**/entities/*.ts"],
+  "entities": ["./src/modules/**/infra/typeorm/entities/*.ts"],
   "cli": {
     "migrationsDir": "./src/shared/infra/typeorm/migrations"
   }

--- a/src/modules/cars/infra/typeorm/repositories/CarsRepository.ts
+++ b/src/modules/cars/infra/typeorm/repositories/CarsRepository.ts
@@ -22,6 +22,7 @@ class CarsRepository implements ICarsRepository {
     brand,
     category_id,
     fine_amount,
+    specifications,
   }: Omit<ICreateCarDTO, 'available'>): Promise<Cars> {
     const car = this.carsRepository.create({
       id,
@@ -32,10 +33,10 @@ class CarsRepository implements ICarsRepository {
       brand,
       category_id,
       fine_amount,
+      specifications,
     });
 
     await this.carsRepository.save(car);
-    console.log(car);
 
     return car;
   }


### PR DESCRIPTION
A falta de não salvar no banco é porque no arquivo **CarsRepository.ts**, no método create, não está desestruturando o specifications e passando logo abaixo.